### PR TITLE
add language in API calls

### DIFF
--- a/pymiele/const.py
+++ b/pymiele/const.py
@@ -7,3 +7,23 @@ OAUTH2_AUTHORIZE = "https://api.mcs3.miele.com/thirdparty/login"
 OAUTH2_TOKEN = "https://api.mcs3.miele.com/thirdparty/token"
 
 AIO_TIMEOUT = 15
+
+LANG_DA = "da"
+LANG_DE = "de"
+LANG_EN = "en"
+LANG_ES = "es"
+LANG_FR = "fr"
+LANG_IT = "it"
+LANG_NL = "nl"
+LANG_NB = "nb"
+
+AVAILABLE_LANGUAGES = [
+    LANG_DA,
+    LANG_DE,
+    LANG_EN,
+    LANG_ES,
+    LANG_FR,
+    LANG_IT,
+    LANG_NL,
+    LANG_NB,
+]


### PR DESCRIPTION
Add language param in API call that accept one;
Allow set language by caller, default to EN